### PR TITLE
Add door unlock control

### DIFF
--- a/server.js
+++ b/server.js
@@ -142,6 +142,21 @@ app.post("/locks/open", async (req, res) => {
   }
 });
 
+app.post("/locks/unlock", async (req, res) => {
+  const { lockId } = req.body;
+  if (!KISI_API_KEY || !lockId) return res.redirect("/");
+  try {
+    await TwilioFetch(`https://api.kisi.com/locks/${lockId}/unlock`, "POST", {
+      Authorization: `KISI-LOGIN ${KISI_API_KEY}`
+    });
+    addEvent({ kind: "action", action: "unlock", lockId });
+    res.redirect("/");
+  } catch (err) {
+    console.error("Unlock door error:", err);
+    res.status(500).send("Failed to unlock door");
+  }
+});
+
 app.post("/locks/lock", async (req, res) => {
   const { lockId } = req.body;
   if (!KISI_API_KEY || !lockId) return res.redirect("/");

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -21,6 +21,12 @@
         <button type="submit" class="btn btn-success">Open Door</button>
       </div>
     </form>
+    <form action="/locks/unlock" method="POST" class="mb-2">
+      <div class="input-group">
+        <input type="number" class="form-control" name="lockId" placeholder="Lock ID" required />
+        <button type="submit" class="btn btn-warning">Unlock Door</button>
+      </div>
+    </form>
     <form action="/locks/lock" method="POST">
       <div class="input-group">
         <input type="number" class="form-control" name="lockId" placeholder="Lock ID" required />


### PR DESCRIPTION
## Summary
- add `POST /locks/unlock` endpoint on the server
- expose an Unlock Door form on the dashboard

## Testing
- `node server.js` *(fails: Cannot find package 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_68482cdca4508326b5333239eccc6671